### PR TITLE
Pin django-model-utils version to 2.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     zip_safe=True,
     install_requires=[
         'django>=1.9.0',
-        'django-model-utils>=2.4.0',
+        'django-model-utils==2.4.0',
         'django-rq>=0.9.3',
         'rq-scheduler>=0.6.0',
         'pytz>=2015.7',


### PR DESCRIPTION
Looks like `django-rq-scheduler` only needs django-model-utils==2.4.0. Currently it causes the latest version of django-model-utils to install which dropped Django 1.x and Python 2.x support. This breaks builds on repos still using Python 2.x and Django 1.x.

This PR pins the required version to fix that.